### PR TITLE
feat: ホーム画面のUI実装

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
+            implementation(libs.compose.materialIconsExtended)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/App.kt
@@ -1,49 +1,21 @@
 package jp.kyamlab.todolist
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import org.jetbrains.compose.resources.painterResource
-
-import todolist.composeapp.generated.resources.Res
-import todolist.composeapp.generated.resources.compose_multiplatform
+import jp.kyamlab.todolist.ui.home.HomeScreen
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
+        HomeScreen(
+            onNavigateToArchive = {
+                println("Navigate to Archive")
+            },
+            onNavigateToDetail = { itemId ->
+                println("Navigate to Detail: $itemId")
             }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
-            }
-        }
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/model/ToDoItem.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/model/ToDoItem.kt
@@ -1,0 +1,9 @@
+package jp.kyamlab.todolist.model
+
+data class ToDoItem(
+    val id: String,
+    val title: String,
+    val description: String = "",
+    val isArchived: Boolean = false,
+    val createdAt: Long = 0L
+)

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
@@ -1,0 +1,228 @@
+package jp.kyamlab.todolist.ui.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import jp.kyamlab.todolist.model.ToDoItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    viewModel: HomeViewModel = viewModel { HomeViewModel() },
+    onNavigateToArchive: () -> Unit,
+    onNavigateToDetail: (String) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    var showAddDialog by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("ToDo List") },
+                actions = {
+                    IconButton(onClick = onNavigateToArchive) {
+                        Icon(
+                            imageVector = Icons.Default.Archive,
+                            contentDescription = "Archive"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Add Task")
+            }
+        }
+    ) { innerPadding ->
+        HomeContent(
+            items = uiState.items,
+            paddingValues = innerPadding,
+            onItemClick = { item -> onNavigateToDetail(item.id) },
+            onArchiveItem = { item -> viewModel.archiveItem(item) }
+        )
+
+        if (showAddDialog) {
+            AddItemDialog(
+                onDismiss = { showAddDialog = false },
+                onAdd = { title ->
+                    viewModel.addItem(title)
+                    showAddDialog = false
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeContent(
+    items: List<ToDoItem>,
+    paddingValues: PaddingValues,
+    onItemClick: (ToDoItem) -> Unit,
+    onArchiveItem: (ToDoItem) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues),
+        contentPadding = PaddingValues(16.dp)
+    ) {
+        // Filter out archived items
+        val displayItems = items.filter { !it.isArchived }
+
+        items(
+            items = displayItems,
+            key = { it.id }
+        ) { item ->
+            val dismissState = rememberSwipeToDismissBoxState(
+                confirmValueChange = {
+                    if (it == SwipeToDismissBoxValue.StartToEnd || it == SwipeToDismissBoxValue.EndToStart) {
+                        onArchiveItem(item)
+                        true
+                    } else {
+                        false
+                    }
+                }
+            )
+
+            SwipeToDismissBox(
+                state = dismissState,
+                backgroundContent = {
+                    val color =
+                        if (dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd) {
+                            Color.Green
+                        } else {
+                            MaterialTheme.colorScheme.errorContainer
+                        }
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(color)
+                            .padding(horizontal = 20.dp),
+                        contentAlignment = if (dismissState.dismissDirection == SwipeToDismissBoxValue.StartToEnd) Alignment.CenterStart else Alignment.CenterEnd
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Archive,
+                            contentDescription = "Archive",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                },
+                content = {
+                    ToDoItemCard(item = item, onClick = { onItemClick(item) })
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun ToDoItemCard(
+    item: ToDoItem,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleMedium
+            )
+            if (item.description.isNotEmpty()) {
+                Text(
+                    text = item.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun AddItemDialog(
+    onDismiss: () -> Unit,
+    onAdd: (String) -> Unit
+) {
+    var text by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add New Task") },
+        text = {
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("Task Title") },
+                singleLine = true
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    if (text.isNotBlank()) {
+                        onAdd(text)
+                    }
+                }
+            ) {
+                Text("Add")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
@@ -1,0 +1,51 @@
+package jp.kyamlab.todolist.ui.home
+
+import androidx.lifecycle.ViewModel
+import jp.kyamlab.todolist.model.ToDoItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class HomeViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+    init {
+        // Dummy data for initial display
+        _uiState.update { currentState ->
+            currentState.copy(
+                items = listOf(
+                    ToDoItem(id = "1", title = "Task 1", description = "Description 1", createdAt = 1000L),
+                    ToDoItem(id = "2", title = "Task 2", description = "Description 2", createdAt = 2000L),
+                    ToDoItem(id = "3", title = "Task 3", description = "Description 3", createdAt = 3000L)
+                )
+            )
+        }
+    }
+
+    fun addItem(title: String) {
+        val newItem = ToDoItem(
+            id = kotlin.random.Random.nextLong().toString(), // Simple ID generation
+            title = title,
+            createdAt = 0L // Placeholder as System.currentTimeMillis() is not available in commonMain without expect/actual or libraries
+        )
+        _uiState.update { currentState ->
+            currentState.copy(items = currentState.items + newItem)
+        }
+    }
+
+    fun archiveItem(item: ToDoItem) {
+        _uiState.update { currentState ->
+            val updatedItems = currentState.items.map {
+                if (it.id == item.id) it.copy(isArchived = true) else it
+            }
+            currentState.copy(items = updatedItems)
+        }
+    }
+}
+
+data class HomeUiState(
+    val items: List<ToDoItem> = emptyList()
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ composeMultiplatform = "1.10.0"
 junit = "4.13.2"
 kotlin = "2.3.0"
 material3 = "1.10.0-alpha05"
+item = "1.0.0" # Placeholder if needed
+materialIconsExtended = "1.7.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -29,6 +31,7 @@ androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
+compose-materialIconsExtended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }


### PR DESCRIPTION
## 概要
TODOリストアプリのホーム画面を実装しました。
要件定義に基づき、タスク一覧の表示、追加、アーカイブ機能を提供します。

## 変更点

### データモデル
- **[NEW] [ToDoItem](cci:2://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/model/ToDoItem.kt:2:0-8:1)**: タスクを表すデータクラス。

### UI (ホーム画面)
- **[NEW] [HomeScreen](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:45:0-97:1)**: メイン画面の実装。
    - `Scaffold` を使用し、トップバー (`TopAppBar`) と FAB (`FloatingActionButton`) を配置。
    - `LazyColumn` でタスク一覧を表示。
    - `SwipeToDismissBox` を使用してスワイプによるアーカイブ操作を実装。
- **[NEW] [HomeViewModel](cci:2://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:9:0-46:1)**: 画面状態 ([HomeUiState](cci:2://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:48:0-50:1)) の管理。タスクの追加・アーカイブ処理を担当。
- **[NEW] [AddItemDialog](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:192:0-227:1)**: 簡易的なタスク追加用ダイアログ。

|ホーム画面|追加ダイアログ|
|:---|:---|
|<img width="200" height="2400" alt="Screenshot_20260215_170127" src="https://github.com/user-attachments/assets/4cc6330a-a9d5-4af1-a134-1806a73c774c" />|<img width="200" height="2400" alt="Screenshot_20260215_170307" src="https://github.com/user-attachments/assets/7b502ef7-03b3-4088-bda0-844ce5c1a617" />|

### 依存関係
- `material-icons-extended:1.7.3` を追加 (`Icons.Filled.Archive` を使用するため)。

### その他
- [App.kt](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/App.kt:0:0-0:0): エントリポイントを [HomeScreen](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:45:0-97:1) を表示するように変更。不要なデモ用コードを削除。

## 動作確認手順
1. アプリを起動し、ホーム画面が表示されることを確認してください。
2. FAB (+) をタップし、タイトルを入力してタスクを追加できることを確認してください。
3. リスト上のタスクを左右どちらかにスワイプし、アーカイブ（リストから消去）されることを確認してください。
4. トップバーのアーカイブアイコンをタップした際、およびタスクをタップした際に、コンソールに遷移ログが出力されることを確認してください。

## 備考
- 現時点ではデータはオンメモリ（ViewModel内）で保持しているため、詳細画面への遷移やアーカイブ画面への遷移はログ出力のみの実装です。
- `material-icons-extended` は Compose Multiplatform 最新版でも v1.7.3 が最新のため、バージョンを固定して指定しています。