### PR TITLE
Compose Multiplatform 文字列リソースの導入

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="app_name">ToDo List</string>
+    <string name="archive">アーカイブ</string>
+    <string name="add_task">タスクを追加</string>
+    <string name="add_new_task">新しいタスクを追加</string>
+    <string name="task_title">タスクのタイトル</string>
+    <string name="add">追加</string>
+    <string name="cancel">キャンセル</string>
+</resources>

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
@@ -42,6 +42,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import jp.kyamlab.todolist.model.ToDoItem
+import org.jetbrains.compose.resources.stringResource
+import todolist.composeapp.generated.resources.Res
+import todolist.composeapp.generated.resources.*
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,12 +59,12 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("ToDo List") },
+                title = { Text(stringResource(Res.string.app_name)) },
                 actions = {
                     IconButton(onClick = onNavigateToArchive) {
                         Icon(
                             imageVector = Icons.Default.Archive,
-                            contentDescription = "Archive"
+                            contentDescription = stringResource(Res.string.archive)
                         )
                     }
                 },
@@ -74,7 +77,7 @@ fun HomeScreen(
         },
         floatingActionButton = {
             FloatingActionButton(onClick = { showAddDialog = true }) {
-                Icon(Icons.Default.Add, contentDescription = "Add Task")
+                Icon(Icons.Default.Add, contentDescription = stringResource(Res.string.add_task))
             }
         }
     ) { innerPadding ->
@@ -147,7 +150,7 @@ fun HomeContent(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Archive,
-                            contentDescription = "Archive",
+                            contentDescription = stringResource(Res.string.archive),
                             tint = MaterialTheme.colorScheme.onSurface
                         )
                     }
@@ -199,12 +202,12 @@ fun AddItemDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Add New Task") },
+        title = { Text(stringResource(Res.string.add_new_task)) },
         text = {
             TextField(
                 value = text,
                 onValueChange = { text = it },
-                label = { Text("Task Title") },
+                label = { Text(stringResource(Res.string.task_title)) },
                 singleLine = true
             )
         },
@@ -216,12 +219,12 @@ fun AddItemDialog(
                     }
                 }
             ) {
-                Text("Add")
+                Text(stringResource(Res.string.add))
             }
         },
         dismissButton = {
             Button(onClick = onDismiss) {
-                Text("Cancel")
+                Text(stringResource(Res.string.cancel))
             }
         }
     )


### PR DESCRIPTION
## 変更の概要
ハードコードされていた固定文言をCompose Multiplatformのリソース管理機能(`compose-components-resources`)を利用するように変更しました。

## 実装の詳細
1. [composeApp/src/commonMain/composeResources/values/strings.xml](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/composeResources/values/strings.xml:0:0-0:0) を新規作成し、以下の文字列を定義しました。
    - アプリ名
    - アーカイブ関連の文言
    - タスク追加関連の文言
    - ボタンのラベル（追加、キャンセル）

2. [HomeScreen.kt](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:0:0-0:0) のリファクタリングを行い、ハードコードされていた文字列を `stringResource(Res.string.xxx)` によるリソース参照に置き換えました。

## 変更ファイル
- [composeApp/src/commonMain/composeResources/values/strings.xml](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/composeResources/values/strings.xml:0:0-0:0): 新規作成
- [composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:0:0-0:0): 変更

## 検証内容
- `./gradlew :composeApp:compileCommonMainKotlinMetadata` コマンドを実行し、コンパイルが成功することを確認しました。
- 生成された `Res` クラスが正常に解決され、コード内で参照できることを確認しました。