### PR TITLE
新規タスク作成ダイアログへの説明入力フィールドの追加

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="add_task">タスクを追加</string>
     <string name="add_new_task">新しいタスクを追加</string>
     <string name="task_title">タスクのタイトル</string>
+    <string name="task_description">タスクの説明</string>
     <string name="add">追加</string>
     <string name="cancel">キャンセル</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
@@ -91,8 +91,8 @@ fun HomeScreen(
         if (showAddDialog) {
             AddItemDialog(
                 onDismiss = { showAddDialog = false },
-                onAdd = { title ->
-                    viewModel.addItem(title)
+                onAdd = { title, description ->
+                    viewModel.addItem(title, description)
                     showAddDialog = false
                 }
             )
@@ -196,26 +196,36 @@ fun ToDoItemCard(
 @Composable
 fun AddItemDialog(
     onDismiss: () -> Unit,
-    onAdd: (String) -> Unit
+    onAdd: (String, String) -> Unit
 ) {
-    var text by remember { mutableStateOf("") }
+    var title by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(Res.string.add_new_task)) },
         text = {
-            TextField(
-                value = text,
-                onValueChange = { text = it },
-                label = { Text(stringResource(Res.string.task_title)) },
-                singleLine = true
-            )
+            Column {
+                TextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    label = { Text(stringResource(Res.string.task_title)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
+                )
+                TextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text(stringResource(Res.string.task_description)) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         },
         confirmButton = {
             Button(
                 onClick = {
-                    if (text.isNotBlank()) {
-                        onAdd(text)
+                    if (title.isNotBlank()) {
+                        onAdd(title, description)
                     }
                 }
             ) {

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
@@ -25,10 +25,11 @@ class HomeViewModel : ViewModel() {
         }
     }
 
-    fun addItem(title: String) {
+    fun addItem(title: String, description: String = "") {
         val newItem = ToDoItem(
             id = kotlin.random.Random.nextLong().toString(), // Simple ID generation
             title = title,
+            description = description,
             createdAt = 0L // Placeholder as System.currentTimeMillis() is not available in commonMain without expect/actual or libraries
         )
         _uiState.update { currentState ->


### PR DESCRIPTION
### 概要
新規タスクを作成する際に、タイトルだけでなく詳細な説明（Description）を入力し、保存できるよう変更しました。

### 変更点
#### UI (HomeScreen.kt)
- [AddItemDialog](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:195:0-240:1) に「タスクの説明」を入力するための `TextField` を追加しました。
- ダイアログ内の状態管理を更新し、タイトルと説明の両方を保持・送信するように変更しました。

#### ViewModel (HomeViewModel.kt)
- [addItem](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:27:4-37:5) 関数を更新し、引数として説明（`description`）を受け取れるようにしました。
- 新しく作成される [ToDoItem](cci:2://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/model/ToDoItem.kt:2:0-8:1) に受け取った説明を正しく設定するようにしました。

#### Resources (strings.xml)
- 説明フィールド用のラベルとして `task_description` 文字列リソースを追加しました。

### 影響範囲
- ホーム画面の新規タスク作成機能にのみ影響します。
- すでにタスク表示側（[ToDoItemCard](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:165:0-193:1)）は説明の表示に対応していたため、既存のUIレイアウトに大きな影響はありません。
