### PR TITLE
リストアイテム編集機能の実装 (BottomSheet)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="add_new_task">新しいタスクを追加</string>
     <string name="task_title">タスクのタイトル</string>
     <string name="task_description">タスクの説明</string>
+    <string name="edit_task">タスクを編集</string>
+    <string name="save">保存</string>
     <string name="add">追加</string>
     <string name="cancel">キャンセル</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
@@ -55,6 +56,10 @@ fun HomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var showAddDialog by remember { mutableStateOf(false) }
+    var showEditSheet by remember { mutableStateOf(false) }
+    var editingItem by remember {
+        mutableStateOf(ToDoItem(id = "", title = "", createdAt = 0L))
+    }
 
     Scaffold(
         topBar = {
@@ -84,8 +89,11 @@ fun HomeScreen(
         HomeContent(
             items = uiState.items,
             paddingValues = innerPadding,
-            onItemClick = { item -> onNavigateToDetail(item.id) },
-            onArchiveItem = { item -> viewModel.archiveItem(item) }
+            onItemClick = { item ->
+                editingItem = item
+                showEditSheet = true
+            },
+            onArchiveItem = { item -> viewModel.archiveItem(item.id) }
         )
 
         if (showAddDialog) {
@@ -96,6 +104,68 @@ fun HomeScreen(
                     showAddDialog = false
                 }
             )
+        }
+
+        if (showEditSheet) {
+            EditItemBottomSheet(
+                item = editingItem,
+                onDismiss = { showEditSheet = false },
+                onSave = { updatedItem ->
+                    viewModel.updateItem(updatedItem)
+                    showEditSheet = false
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditItemBottomSheet(
+    item: ToDoItem,
+    onDismiss: () -> Unit,
+    onSave: (ToDoItem) -> Unit
+) {
+    var title by remember { mutableStateOf(item.title) }
+    var description by remember { mutableStateOf(item.description) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .padding(bottom = 32.dp) // Extra padding for bottom
+        ) {
+            Text(
+                text = stringResource(Res.string.edit_task),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+            TextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text(stringResource(Res.string.task_title)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
+            )
+            TextField(
+                value = description,
+                onValueChange = { description = it },
+                label = { Text(stringResource(Res.string.task_description)) },
+                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)
+            )
+            Button(
+                onClick = {
+                    if (title.isNotBlank()) {
+                        onSave(item.copy(title = title, description = description))
+                    }
+                },
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text(stringResource(Res.string.save))
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
@@ -17,9 +17,24 @@ class HomeViewModel : ViewModel() {
         _uiState.update { currentState ->
             currentState.copy(
                 items = listOf(
-                    ToDoItem(id = "1", title = "Task 1", description = "Description 1", createdAt = 1000L),
-                    ToDoItem(id = "2", title = "Task 2", description = "Description 2", createdAt = 2000L),
-                    ToDoItem(id = "3", title = "Task 3", description = "Description 3", createdAt = 3000L)
+                    ToDoItem(
+                        id = "1",
+                        title = "Task 1",
+                        description = "Description 1",
+                        createdAt = 1000L
+                    ),
+                    ToDoItem(
+                        id = "2",
+                        title = "Task 2",
+                        description = "Description 2",
+                        createdAt = 2000L
+                    ),
+                    ToDoItem(
+                        id = "3",
+                        title = "Task 3",
+                        description = "Description 3",
+                        createdAt = 3000L
+                    )
                 )
             )
         }
@@ -37,12 +52,31 @@ class HomeViewModel : ViewModel() {
         }
     }
 
-    fun archiveItem(item: ToDoItem) {
+    fun archiveItem(id: String) {
         _uiState.update { currentState ->
-            val updatedItems = currentState.items.map {
-                if (it.id == item.id) it.copy(isArchived = true) else it
+            val index = currentState.items.indexOfFirst { it.id == id }
+            if (index != -1) {
+                val updatedItems = currentState.items.toMutableList().apply {
+                    this[index] = this[index].copy(isArchived = true)
+                }
+                currentState.copy(items = updatedItems)
+            } else {
+                currentState
             }
-            currentState.copy(items = updatedItems)
+        }
+    }
+
+    fun updateItem(item: ToDoItem) {
+        _uiState.update { currentState ->
+            val index = currentState.items.indexOfFirst { it.id == item.id }
+            if (index != -1) {
+                val updatedItems = currentState.items.toMutableList().apply {
+                    set(index, item)
+                }
+                currentState.copy(items = updatedItems)
+            } else {
+                currentState
+            }
         }
     }
 }


### PR DESCRIPTION
## 概要
ToDoリストのアイテムをタップした際、詳細画面へ遷移する代わりに BottomSheet を開き、その場でタイトルと説明を編集できる機能を実装しました。

## 変更内容

### UI
- `ModalBottomSheet` を使用した [EditItemBottomSheet](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:121:0-170:1) コンポーネントを追加
- リストアイテムタップ時のアクションを「詳細画面への遷移」から「編集用 BottomSheet の表示」に変更
- [strings.xml](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/composeResources/values/strings.xml:0:0-0:0) に編集機能用の日本語リソース (`edit_task`, `save`) を追加

### ViewModel / Logic
- [HomeViewModel](cci:2://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:9:0-81:1) にアイテム更新用の [updateItem(item: ToDoItem)](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:68:4-80:5) メソッドを追加
- [archiveItem(id: String)](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:54:4-66:5) を ID のみを受け取る形式にリファクタリングし、インターフェースを整理
- リスト更新ロジックを `indexOfFirst` を使用した効率的な実装に変更

## 修正のポイント
- **効率性:** 大規模なリストでもパフォーマンスが低下しないよう、全要素の `map` ではなくインデックス特定による置換を採用しました。
- **安全性:** 編集中のアイテム状態を Null 非許容で管理し、予期せぬクラッシュを防止しています。
- **一貫性:** 編集機能 ([updateItem](cci:1://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt:68:4-80:5)) では既存のアーカイブ状態を保持し、意図せずタスクがアーカイブされないように設計しています。

## 影響範囲
- [HomeScreen.kt](cci:7://file:///Users/kyohei/Projects/ToDoList/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt:0:0-0:0)
- `HomeViewModel.kt`
- `strings.xml`
