### PR TITLE
アーカイブ画面の作成

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="save">保存</string>
     <string name="add">追加</string>
     <string name="cancel">キャンセル</string>
+    <string name="unarchive">アーカイブを解除</string>
+    <string name="no_archived_tasks">アーカイブされたタスクはありません</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/App.kt
@@ -3,19 +3,25 @@ package jp.kyamlab.todolist
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.tooling.preview.Preview
+import jp.kyamlab.todolist.ui.archive.ArchiveScreen
 import jp.kyamlab.todolist.ui.home.HomeScreen
+
+private enum class Screen { Home, Archive }
 
 @Composable
 @Preview
 fun App() {
+    var currentScreen by remember { mutableStateOf(Screen.Home) }
+
     MaterialTheme {
-        HomeScreen(
-            onNavigateToArchive = {
-                println("Navigate to Archive")
-            },
-            onNavigateToDetail = { itemId ->
-                println("Navigate to Detail: $itemId")
-            }
-        )
+        when (currentScreen) {
+            Screen.Home -> HomeScreen(
+                onNavigateToArchive = { currentScreen = Screen.Archive },
+                onNavigateToDetail = { itemId -> println("Navigate to Detail: $itemId") }
+            )
+            Screen.Archive -> ArchiveScreen(
+                onNavigateBack = { currentScreen = Screen.Home }
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/data/ToDoRepository.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/data/ToDoRepository.kt
@@ -1,0 +1,40 @@
+package jp.kyamlab.todolist.data
+
+import jp.kyamlab.todolist.model.ToDoItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+object ToDoRepository {
+    private val _items = MutableStateFlow(
+        listOf(
+            ToDoItem(id = "1", title = "Task 1", description = "Description 1", createdAt = 1000L),
+            ToDoItem(id = "2", title = "Task 2", description = "Description 2", createdAt = 2000L),
+            ToDoItem(id = "3", title = "Task 3", description = "Description 3", createdAt = 3000L)
+        )
+    )
+    val items: StateFlow<List<ToDoItem>> = _items.asStateFlow()
+
+    fun addItem(title: String, description: String = "") {
+        val newItem = ToDoItem(
+            id = kotlin.random.Random.nextLong().toString(),
+            title = title,
+            description = description,
+            createdAt = 0L
+        )
+        _items.update { it + newItem }
+    }
+
+    fun archiveItem(id: String) {
+        _items.update { items -> items.map { if (it.id == id) it.copy(isArchived = true) else it } }
+    }
+
+    fun unarchiveItem(id: String) {
+        _items.update { items -> items.map { if (it.id == id) it.copy(isArchived = false) else it } }
+    }
+
+    fun updateItem(item: ToDoItem) {
+        _items.update { items -> items.map { if (it.id == item.id) item else it } }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/archive/ArchiveScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/archive/ArchiveScreen.kt
@@ -1,0 +1,121 @@
+package jp.kyamlab.todolist.ui.archive
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Unarchive
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import jp.kyamlab.todolist.ui.home.ToDoItemCard
+import org.jetbrains.compose.resources.stringResource
+import todolist.composeapp.generated.resources.Res
+import todolist.composeapp.generated.resources.archive
+import todolist.composeapp.generated.resources.no_archived_tasks
+import todolist.composeapp.generated.resources.unarchive
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArchiveScreen(
+    viewModel: ArchiveViewModel = viewModel { ArchiveViewModel() },
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.archive)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { innerPadding ->
+        if (uiState.items.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(Res.string.no_archived_tasks),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentPadding = PaddingValues(16.dp)
+            ) {
+                items(items = uiState.items, key = { it.id }) { item ->
+                    val dismissState = rememberSwipeToDismissBoxState(
+                        confirmValueChange = {
+                            if (it == SwipeToDismissBoxValue.StartToEnd || it == SwipeToDismissBoxValue.EndToStart) {
+                                viewModel.unarchiveItem(item.id)
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                    )
+                    SwipeToDismissBox(
+                        state = dismissState,
+                        backgroundContent = {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 20.dp),
+                                contentAlignment = Alignment.CenterStart
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Unarchive,
+                                    contentDescription = stringResource(Res.string.unarchive),
+                                    tint = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        },
+                        content = {
+                            ToDoItemCard(
+                                item = item,
+                                onClick = {},
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/archive/ArchiveViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/archive/ArchiveViewModel.kt
@@ -1,0 +1,25 @@
+package jp.kyamlab.todolist.ui.archive
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import jp.kyamlab.todolist.data.ToDoRepository
+import jp.kyamlab.todolist.model.ToDoItem
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+class ArchiveViewModel : ViewModel() {
+
+    val uiState: StateFlow<ArchiveUiState> = ToDoRepository.items
+        .map { items -> ArchiveUiState(items = items.filter { it.isArchived }) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ArchiveUiState())
+
+    fun unarchiveItem(id: String) {
+        ToDoRepository.unarchiveItem(id)
+    }
+}
+
+data class ArchiveUiState(
+    val items: List<ToDoItem> = emptyList()
+)

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeScreen.kt
@@ -236,10 +236,11 @@ fun HomeContent(
 @Composable
 fun ToDoItemCard(
     item: ToDoItem,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
             .clickable(onClick = onClick),

--- a/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kyamlab/todolist/ui/home/HomeViewModel.kt
@@ -1,83 +1,30 @@
 package jp.kyamlab.todolist.ui.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import jp.kyamlab.todolist.data.ToDoRepository
 import jp.kyamlab.todolist.model.ToDoItem
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 class HomeViewModel : ViewModel() {
 
-    private val _uiState = MutableStateFlow(HomeUiState())
-    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
-
-    init {
-        // Dummy data for initial display
-        _uiState.update { currentState ->
-            currentState.copy(
-                items = listOf(
-                    ToDoItem(
-                        id = "1",
-                        title = "Task 1",
-                        description = "Description 1",
-                        createdAt = 1000L
-                    ),
-                    ToDoItem(
-                        id = "2",
-                        title = "Task 2",
-                        description = "Description 2",
-                        createdAt = 2000L
-                    ),
-                    ToDoItem(
-                        id = "3",
-                        title = "Task 3",
-                        description = "Description 3",
-                        createdAt = 3000L
-                    )
-                )
-            )
-        }
-    }
+    val uiState: StateFlow<HomeUiState> = ToDoRepository.items
+        .map { items -> HomeUiState(items = items.filter { !it.isArchived }) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HomeUiState())
 
     fun addItem(title: String, description: String = "") {
-        val newItem = ToDoItem(
-            id = kotlin.random.Random.nextLong().toString(), // Simple ID generation
-            title = title,
-            description = description,
-            createdAt = 0L // Placeholder as System.currentTimeMillis() is not available in commonMain without expect/actual or libraries
-        )
-        _uiState.update { currentState ->
-            currentState.copy(items = currentState.items + newItem)
-        }
+        ToDoRepository.addItem(title, description)
     }
 
     fun archiveItem(id: String) {
-        _uiState.update { currentState ->
-            val index = currentState.items.indexOfFirst { it.id == id }
-            if (index != -1) {
-                val updatedItems = currentState.items.toMutableList().apply {
-                    this[index] = this[index].copy(isArchived = true)
-                }
-                currentState.copy(items = updatedItems)
-            } else {
-                currentState
-            }
-        }
+        ToDoRepository.archiveItem(id)
     }
 
     fun updateItem(item: ToDoItem) {
-        _uiState.update { currentState ->
-            val index = currentState.items.indexOfFirst { it.id == item.id }
-            if (index != -1) {
-                val updatedItems = currentState.items.toMutableList().apply {
-                    set(index, item)
-                }
-                currentState.copy(items = updatedItems)
-            } else {
-                currentState
-            }
-        }
+        ToDoRepository.updateItem(item)
     }
 }
 


### PR DESCRIPTION
## 概要

issue #6 の対応。アーカイブ済みタスクを一覧表示するアーカイブ画面を実装。

## 変更内容

- `ToDoRepository`（シングルトン）を追加し、ホーム画面とアーカイブ画面で状態を共有
- `ArchiveScreen` / `ArchiveViewModel` を新規作成
- アーカイブ済みタスクの一覧表示・スワイプでアンアーカイブ・空状態の表示に対応
- `App.kt` に `Screen` enum によるシンプルなナビゲーションを実装
- `HomeViewModel` を `ToDoRepository` を使うよう刷新

## テスト手順

- [x] ホーム画面右上のアーカイブアイコンをタップするとアーカイブ画面に遷移する
- [x] ホーム画面でタスクをスワイプするとアーカイブされ、アーカイブ画面に表示される
- [x] アーカイブ画面でタスクをスワイプするとホーム画面に戻る
- [x] アーカイブ画面の戻るボタンでホーム画面に戻れる
- [x] アーカイブが空のときに「アーカイブされたタスクはありません」と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)